### PR TITLE
Help automated tools recognize BSD 3-Clause License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
-[The BSD 3-Clause License]
+BSD 3-Clause License
 
-Copyright (c) Anymail Contributors.
-All rights reserved.
+Copyright (c) 2016-2024, Anymail Contributors
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:


### PR DESCRIPTION
This project has always been licensed under the BSD 3-Clause license.

Certain automated tools (ahem, GitHub) have recently stoped recognizing the license text as being the BSD 3-Clause license.

This attempts to adjust the license text to match the tools' expectations. The licensing of the project HAS NOT CHANGED.